### PR TITLE
[DS-566] set HTML lang attribute

### DIFF
--- a/web/atlas_meta/atlas/templates/rest_framework/base.html
+++ b/web/atlas_meta/atlas/templates/rest_framework/base.html
@@ -1,0 +1,4 @@
+<!DOCTYPE html>
+<html lang="en-US">
+{% extends "rest_framework/base.html" %}
+</html>

--- a/web/atlas_meta/atlas_meta/settings.py
+++ b/web/atlas_meta/atlas_meta/settings.py
@@ -61,7 +61,7 @@ ROOT_URLCONF = 'atlas_meta.urls'
 TEMPLATES = [
     {
         'BACKEND': 'django.template.backends.django.DjangoTemplates',
-        'DIRS': [],
+        'DIRS': [os.path.join(BASE_DIR, 'atlas/templates')],
         'APP_DIRS': True,
         'OPTIONS': {
             'context_processors': [


### PR DESCRIPTION
Based on the external audit on accessibility the lang attribute must be set for the current API under api.data.amsterdam.nl.

Added a base.html template that contains the html lang attribute.