### PR TITLE
AB#92881 Use official Python image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3.0'
 services:
   database:
     image: amsterdam/postgres11
@@ -13,8 +12,6 @@ services:
     build: ./web
     ports:
       - "8101:8000"
-    links:
-      - database
     environment:
       DATABASE_NAME: metadata
       DATABASE_USER: metadata

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -1,12 +1,13 @@
-FROM amsterdam/python
+FROM python:3.7-bookworm
 MAINTAINER datapunt@amsterdam.nl
 
 ENV PYTHONUNBUFFERED 1
 
 EXPOSE 8000
 
-RUN apt-get install -y \
-        netcat \
+RUN apt-get update && apt-get install -y \
+	gdal-bin \
+	libpcre3 libpcre3-dev \
 	&& apt-get clean \
 	&& rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
 	&& adduser --system datapunt \

--- a/web/requirements.txt
+++ b/web/requirements.txt
@@ -13,7 +13,7 @@ drf-hal-json==0.9.1
 drf-nested-fields==0.9.4
 factory-boy==2.11.1
 Faker==1.0.1
-psycopg2-binary==2.7.6.1
+psycopg2-binary==2.9.8
 pyslack-real==0.6.0
 python-dateutil==2.7.5
 pytz==2018.9


### PR DESCRIPTION
Replace old unsupported amsterdam/python image with bookworm based official Python image

Upgrade psycopg2 for openssl2 support to prevent uwsgi segfault